### PR TITLE
Expanded the `safe_malloc` and added documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,5 +5,6 @@ project ("Safe C" C)
 
 include_directories(include)
 
-add_library(safe-c src/safe_memory.c)
+add_library(safe-c src/safe_memory.c
+                   src/safe_string.c)
 

--- a/include/safe-c/safe_memory.h
+++ b/include/safe-c/safe_memory.h
@@ -3,7 +3,33 @@
 
 #include <malloc.h>
 
+/**
+ * Memory allocation with strict boundary and error checking.
+ *
+ * @param size
+ *      The size in bytes to be allocated. Be aware that size in an unsigned
+ *      type, passing signed values can lead to conversion errors.
+ *      If `size == 0`, this function will call `exit()` and print an error
+ *      message indicating with function requested zero memory. You should set
+ *      your pointer to NULL yourself explicitly if you want a pointer without
+ *      memory allocation.
+ *
+ * @param calling_function
+ *      The name of the function calling this function. You can pass a
+ *      custom NULL termination string, or pass the __FUNCTION__ define. You
+ *      can use the macro function `safe_malloc(size)`, which will automatically
+ *      pass the __FUNCTION__ define as second parameter. This usage is the most
+ *      convenient because the calling it will be the same as `malloc`.
+ *
+ * @return
+ *      The return value will be a pointer to the allocated memory, the memory
+ *      will be initialized to all zero.
+ *      If for some reason the memory couldn't be allocated, this function will
+ *      call `exit()` and print an error message indicating the caller function
+ *      and the amount of memory request.
+ */
 void* safe_malloc_function(size_t size, const char* calling_function);
+
 #define safe_malloc(size) safe_malloc_function(size, __FUNCTION__);
 
 void safe_free_function(void** pointer);

--- a/include/safe-c/safe_memory.h
+++ b/include/safe-c/safe_memory.h
@@ -4,5 +4,9 @@
 #include <malloc.h>
 
 void* safe_malloc_function(size_t size, const char* calling_function);
+#define safe_malloc(size) safe_malloc_function(size, __FUNCTION__);
+
+void safe_free_function(void** pointer);
+#define safe_free(pointer) safe_free_function((void **) &(pointer))
 
 #endif /* SAFE_MEMORY_H_ */

--- a/include/safe-c/safe_string.h
+++ b/include/safe-c/safe_string.h
@@ -1,6 +1,8 @@
 #ifndef SAFE_STRING_H_
 #define SAFE_STRING_H_
 
+typedef char* c_string;
+typedef c_string* c_string_array;
 
 
 #endif /* SAFE_STRING_H_ */

--- a/include/safe-c/safe_string.h
+++ b/include/safe-c/safe_string.h
@@ -1,0 +1,6 @@
+#ifndef SAFE_STRING_H_
+#define SAFE_STRING_H_
+
+
+
+#endif /* SAFE_STRING_H_ */

--- a/src/safe_memory.c
+++ b/src/safe_memory.c
@@ -8,13 +8,19 @@ void* safe_malloc_function(size_t size, const char* calling_function)
 {
     if (size == 0)
     {
-        return NULL;
+        fprintf(stderr, "Error allocating memory: The function %s called "
+                "'safe_malloc' and requested zero memory. The pointer should "
+                "be explicitly set to NULL instead.\n",
+                calling_function);
+        exit(EXIT_FAILURE);
     }
 
     void* memory = malloc(size);
     if (!memory)
     {
-        fprintf(stderr, "Error: not enough memory for malloc in function: %s",
+        fprintf(stderr, "Error allocating memory: The function %s called "
+                "'safe_malloc' requesting %u bytes of memory, but an error "
+                "occurred allocating this amount of memory. Exiting",
                 calling_function);
         exit(EXIT_FAILURE);
     }

--- a/src/safe_memory.c
+++ b/src/safe_memory.c
@@ -21,3 +21,12 @@ void* safe_malloc_function(size_t size, const char* calling_function)
     memset(memory, 0, size);
     return memory;
 }
+
+void safe_free_function(void** pointer)
+{
+    if (pointer != NULL)
+    {
+        free(*pointer);
+        *pointer = NULL;
+    }
+}

--- a/src/safe_string.c
+++ b/src/safe_string.c
@@ -1,0 +1,3 @@
+#include "safe-c/safe_string.h"
+
+


### PR DESCRIPTION
Added documentation for the `safe_malloc` function in Doxygen style.
Changed the behavior when zero is passing to `safe_malloc`. Instead of return NULL, it calls exit. This way you can be sure that `safe_malloc` _never_ returns NULL.

Also added two empty files that will include the code for safe string functions.