### PR TITLE
Fix: Add value parameter to fprintf in safe_malloc

### DIFF
--- a/src/safe_memory.c
+++ b/src/safe_memory.c
@@ -19,12 +19,12 @@ void* safe_malloc_function(size_t size, const char* calling_function)
     if (!memory)
     {
         fprintf(stderr, "Error allocating memory: The function %s called "
-                "'safe_malloc' requesting %u bytes of memory, but an error "
+                "'safe_malloc' requesting %zu bytes of memory, but an error "
                 "occurred allocating this amount of memory. Exiting",
-                calling_function);
+                calling_function, size);
         exit(EXIT_FAILURE);
     }
-    memset(memory, 0, size);
+    memory = memset(memory, 0, size);
     return memory;
 }
 


### PR DESCRIPTION
Changed the value type in the `fprintf` from `u` to `zu`, this is because `size` is of type `size_t` and not `unsigned int`.
In addation, asign the return value of memset to `memory`.