### PR TITLE
Enabled compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 project ("Safe C" C)
 
+if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR
+    ${CMAKE_C_COMPILER_ID} STREQUAL "Clang")
+    set(warnings "-Wall -Wextra -Werror -Wmissing-include-dirs -Wswitch-default -Wfloat-equal -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wconversion -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wdouble-promotion -Wtrampolines -Wlogical-op")
+elseif (${CMAKE_C_COMPILER_ID} STREQUAL "MSVC")
+    set(warnings "/W4 /WX /wd4996")
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${warnings}")
+
+
 include_directories(include)
 
 add_library(safe-c src/safe_memory.c


### PR DESCRIPTION
Set the warning level to W4 for MSVC, enable multiple warnings for GCC and Clang.
Treat warnings like errors.
Disable warning C4996 when compiling with MSVC.