### PR TITLE
Download Criterion release instead of building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,10 @@ cmake_install.cmake
 install_manifest.txt
 CTestTestfile.cmake
 
-# Build directroy
+# Download directory for external dependencies
+dependencies/*
+
+# Build directory
 build/*
 
 # Eclipse project files

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,12 @@ env:
 install:
   # Install the Criterion unit testing framework
   - cd ${TRAVIS_BUILD_DIR}
-  - cd dependencies/criterion/
-  - cmake .
-  - make
-  - sudo make install
+  - mkdir dependencies
+  - cd dependencies
+  - wget https://github.com/Snaipe/Criterion/releases/download/v2.2.2/criterion-v2.2.2-linux-x86_64.tar.bz2 -O criterion.tar.bz2
+  - tar xvjf criterion.tar.bz2
+  - mv criterion-v2.2.2/* .
+  - sudo mv lib/libcriterion.so /usr/local/lib/libcriterion.so
   - sudo ldconfig
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,10 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 
 project ("Safe C" C)
 
-if (${CMAKE_C_COMPILER_ID} STREQUAL GNU OR
+if(${CMAKE_C_COMPILER_ID} STREQUAL GNU OR
     ${CMAKE_C_COMPILER_ID} STREQUAL Clang)
-    set(warnings "-Wall -Wextra -Werror -Wmissing-include-dirs -Wswitch-default -Wfloat-equal -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wconversion -Wstrict-prototypes -Wmissing-prototypes -Wnested-externs -Wdouble-promotion -Wtrampolines -Wlogical-op")
+    # -Wstrict-prototypes can't be used because it causes errors in Criterion
+    set(warnings "-Wall -Wextra -Werror -Wmissing-include-dirs -Wswitch-default -Wfloat-equal -Wundef -Wshadow -Wpointer-arith -Wbad-function-cast -Wcast-qual -Wconversion -Wmissing-prototypes -Wnested-externs -Wdouble-promotion -Wtrampolines -Wlogical-op")
 elseif (${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
     set(warnings "/W4 /WX /wd4996")
 endif()
@@ -20,15 +21,19 @@ add_library(safe-c include/safe-c/safe_memory.h
                    src/safe_memory.c
                    src/safe_string.c)
 
+# ----- Check for dependencies -----
+link_directories(${CMAKE_CURRENT_SOURCE_DIR}/dependencies/lib)
+
+if(IS_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/dependencies/include)
+    include_directories(dependencies/include)
+endif()
+
+# Criterion is the unit testing framework and is required for building the tests.
 find_library(CRITERION criterion)
-
 if(CRITERION)
-    if (${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
-        # For now, assume that criterion.lib is located in this folder on Windows.
-        link_directories(${CMAKE_CURRENT_SOURCE_DIR}/dependencies/criterion/build/Release/)
-        include_directories(dependencies/criterion/include)
-    endif()
-
+    message(STATUS "Criterion - found")
     enable_testing()
     add_subdirectory(tests)
+else(CRITERION)
+    message(STATUS "Criterion - not found")
 endif()

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,17 +7,19 @@ environment:
 
 init:
   - del "C:\Program Files (x86)\MSBuild\14.0\Microsoft.Common.targets\ImportAfter\Xamarin.Common.targets"
-install:
-  # Update submodules
-  - git submodule update --init
 
-  # Build Criterion unit testing framework
-  - cd %APPVEYOR_BUILD_FOLDER%\dependencies\criterion
-  - mkdir build
-  - cd build
-  - cmake ..
-  - cmake --build . --config Release
-  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\dependencies\criterion\build\Release
+install:
+# Download and setup Criterion unit testing framework.
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - mkdir dependencies
+  - cd dependencies
+  - ps: wget https://github.com/Snaipe/Criterion/releases/download/v2.2.2/criterion-v2.2.2-windows-msvc-x64.tar.bz2 -o criterion.tar.bz2
+  - 7z x criterion.tar.bz2
+  - 7z x criterion.tar
+  - move criterion-v2.2.2\bin .
+  - move criterion-v2.2.2\include .
+  - move criterion-v2.2.2\lib .
+  - set PATH=%PATH%;%APPVEYOR_BUILD_FOLDER%\dependencies\bin
 
 build_script:
   - cd %APPVEYOR_BUILD_FOLDER%


### PR DESCRIPTION
Instead of keeping Criterion as a submodule and build it every time on
Travis and Appveyor, download the latest release (v2.2.2 during time of
writing) and use that. This reduces download time, build time and build
log length.
The reason for using a submodule before, was that Criterion version v2.2.1
generated warnings when compiling the tests, along with other issues that
are fixed in v2.2.2.