### PR TITLE
Fixed 7 defects detected by Coverity in unit tests

### DIFF
--- a/tests/safe_memory/safe_calloc.c
+++ b/tests/safe_memory/safe_calloc.c
@@ -21,17 +21,20 @@ Test(safe_calloc, both_zero_expect_exit, .exit_code = 1)
 
 Test(safe_calloc, number_of_elements_max_expect_exit, .exit_code = 1)
 {
-    safe_calloc(SIZE_MAX, 10);
+    void* pointer = safe_calloc(SIZE_MAX, 10);
+    safe_free(pointer);
 }
 
 Test(safe_calloc, element_size_max_expect_exit, .exit_code = 1)
 {
-    safe_calloc(10, SIZE_MAX);
+    void* pointer = safe_calloc(10, SIZE_MAX);
+    safe_free(pointer);
 }
 
 Test(safe_calloc, both_max_expect_exit, .exit_code = 1)
 {
-    safe_calloc(SIZE_MAX, SIZE_MAX);
+    void* pointer = safe_calloc(SIZE_MAX, SIZE_MAX);
+    safe_free(pointer);
 }
 
 Test(safe_calloc, one_one_success, .exit_code = 0)

--- a/tests/safe_memory/safe_free.c
+++ b/tests/safe_memory/safe_free.c
@@ -16,5 +16,5 @@ Test(safe_free, null_succeed)
 Test(safe_free, free_malloced_succeed)
 {
     void* pointer = safe_malloc(50);
-    safe_free_function(pointer);
+    safe_free(pointer);
 }

--- a/tests/safe_memory/safe_malloc.c
+++ b/tests/safe_memory/safe_malloc.c
@@ -11,7 +11,8 @@ Test(safe_malloc, zero_expect_exit, .exit_code = 1)
 
 Test(safe_malloc, max_expect_exit, .exit_code = 1)
 {
-    safe_malloc(SIZE_MAX);
+    void* pointer = safe_malloc(SIZE_MAX);
+    safe_free(pointer);
 }
 
 Test(safe_malloc, one_success, .exit_code = 0)

--- a/tests/safe_memory/safe_realloc.c
+++ b/tests/safe_memory/safe_realloc.c
@@ -12,13 +12,15 @@ Test(safe_realloc, address_null_size_valid_expect_exit, .exit_code = 1)
 Test(safe_realloc, pointer_valid_size_zero_expect_exit, .exit_code = 1)
 {
     void* pointer = safe_malloc(10);
-    safe_realloc(pointer, 0);
+    pointer = safe_realloc(pointer, 0);
+    safe_free(pointer);
 }
 
 Test(safe_realloc, pointer_valid_size_SIZE_MAX_expect_exit, .exit_code = 1)
 {
     void* pointer = safe_malloc(10);
-    safe_realloc(pointer, SIZE_MAX);
+    pointer = safe_realloc(pointer, SIZE_MAX);
+    safe_free(pointer);
 }
 
 Test(safe_realloc, pointer_NULL_size_valid)


### PR DESCRIPTION
In one defect, `safe_free_function` was called while it should have been
`safe_free` in the unit test `safe_free.c`. This is corrected.
The other defects were test cases were failure to allocate memory is
assumed by inputting large values. However, if memory allocation in these
cases does succeed, no cleanup is performed which be lead to a "Resource
leak" defect. This is fixed by performing cleanup in these test cases,
should memory allocation succeed.